### PR TITLE
chore: append uuid to make each message a new key in redis

### DIFF
--- a/redis-e2e-test-sink/go.mod
+++ b/redis-e2e-test-sink/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/go-redis/redis/v8 v8.11.4
+	github.com/google/uuid v1.1.2
 	github.com/numaproj/numaflow-go v0.3.0
 )
 

--- a/redis-e2e-test-sink/go.sum
+++ b/redis-e2e-test-sink/go.sum
@@ -29,9 +29,9 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/numaproj/numaflow-go v0.2.3 h1:DDyLK6SehUmXUq/RwQemawPd3TfXqJLepA1fwYUrN0U=
-github.com/numaproj/numaflow-go v0.2.3/go.mod h1:jwhmgurhkWs3YMzpPPl4qXf3OohdE18jc0YKM7Ux2iQ=
 github.com/numaproj/numaflow-go v0.3.0 h1:ry2C67eMcZ6MAgWn8BOPbRjAWIwMg5T5F7mdsvfJAYA=
 github.com/numaproj/numaflow-go v0.3.0/go.mod h1:TOawJdyf1C4V98zKnjjFhbHLBtg/TDyzZM+1MsfZuPo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/redis-e2e-test-sink/main.go
+++ b/redis-e2e-test-sink/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"github.com/google/uuid"
 	"log"
 	"time"
 
@@ -24,12 +26,15 @@ func handle(ctx context.Context, datumStreamCh <-chan sinksdk.Datum) sinksdk.Res
 
 		// Our E2E tests time out after 10 minutes. Set redis message TTL to the same.
 		const msgTTL = 10 * time.Minute
-		err := client.Set(ctx, string(d.Value()), 1, msgTTL).Err()
+		// When redis sink receives two datum with same data, e2e tests should be able to verify two occurrences.
+		// We append an uuid to the datum, to make the key globally unique. Such that two datum with same data get persisted in redis as two separate keys.
+		key := fmt.Sprintf("%s-%s", string(d.Value()), uuid.New().String())
+		err := client.Set(ctx, key, 1, msgTTL).Err()
 
 		if err != nil {
 			log.Println("Set Error - ", err)
 		} else {
-			log.Printf("Added key %s\n", string(d.Value()))
+			log.Printf("Added key %s\n", key)
 		}
 
 		id := d.ID()


### PR DESCRIPTION
Mainly to accommodate [http e2e test](https://github.com/numaproj/numaflow/blob/main/test/http-e2e/http_test.go#L64) but should also be useful for future tests.

Signed-off-by: Keran Yang <yangkr920208@gmail.com>