### PR TITLE
chore: update redis udsink to use hashes to store data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 vendor/
 .idea/
-http-sink/dist/
+*/dist/
 http-sink/vendor/


### PR DESCRIPTION
For each sink, we create its own hash key to store data written by itself, such that when we have multiple sinks writing to redis, during data verification, we will just look into one hash key instead of scanning through all.

Signed-off-by: Keran Yang <yangkr920208@gmail.com>